### PR TITLE
Add trailing "ends here" line for package.el compatibility

### DIFF
--- a/bdo.el
+++ b/bdo.el
@@ -246,3 +246,4 @@ current buffer, tries to get from 'load-path."
       (url-unhex-string (replace-regexp-in-string "+" "%20" post-data)))))
 
 (provide 'bdo)
+;;; bdo.el ends here


### PR DESCRIPTION
Without this line, package.el pedantically refuses to install this library. (Background: I'm adding a [MELPA](http://melpa.milkbox.net/) recipe for `bdo`)

BTW, you might also be interested in [skewer-mode](https://github.com/skeeto/skewer-mode), which uses a similar approach to yours in order to connect a js repl to a browser.
